### PR TITLE
feat: use POST as default HTTP method instead of GET

### DIFF
--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -37,7 +37,7 @@ local schema = {
             }, {
                 http_method = {
                     type = "string",
-                    default = "GET"
+                    default = "POST"
                 }
             }, {
                 authz_url = {


### PR DESCRIPTION
Use POST as the default method for authentication, so that it works out of the box with Frontier's authentication API.