### PR TITLE
Add override_authz_header to schema

### DIFF
--- a/kong/plugins/frontier/access.lua
+++ b/kong/plugins/frontier/access.lua
@@ -123,6 +123,10 @@ function _M.run(conf)
     local user_token = check_request_identity(conf, cookies, bearer)
     kong.service.request.set_header(conf.header_name, user_token)
 
+    if conf.override_authz_header then
+        kong.service.request.set_header("Authorization", "Bearer " .. user_token)
+    end
+
     -- verify user permission(path authz)
     if conf.authz_url then
         if conf.rule then

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -45,7 +45,7 @@ local schema = {
                 }
             }, {
                 override_authz_header = {
-                    type = "string",
+                    type = "boolean",
                     default = true
                 }
             }, {

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -44,6 +44,11 @@ local schema = {
                     type = "string"
                 }
             }, {
+                override_authz_header = {
+                    type = "string",
+                    default = true
+                }
+            }, {
                 rule = {
                     type = "record",
                     fields = {{


### PR DESCRIPTION
The override_authz_header configuration, when set to true, will set the 'Authorization' header to "Bearer <token_received_from_frontier>"