### PR TITLE
[IDE-150] JWT claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 tmp
+servroot
+pongo

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ header_name = {
 http_method = {
     type = "string",
     default = "GET"
+},
+add_token_claims_as_headers = {
+    type = "boolean",
+    default = true
+}
+frontier_header_prefix = {
+    type = "string",
+    default = "X-Frontier-"
+},
+appendable_claim_headers = {
+    type = "array",
+    default = BEARER_TOKEN_HEADERS,
+    elements = {
+        type = "string"
+    }
 }
 ```
 - For local development linting
@@ -48,6 +63,27 @@ brew install wget
 brew install luarocks
 luarocks install luacheck
 ```
+
+- For running tests locally
+Unit tests are written in [Kong Pongo](https://github.com/Kong/kong-pongo)
+
+Installation:
+```
+git clone git@github.com:Kong/kong-pongo.git
+PATH=$PATH:~/.local/bin
+git clone https://github.com/Kong/kong-pongo.git
+mkdir -p ~/.local/bin
+ln -s $(realpath kong-pongo/pongo.sh) ~/.local/bin/pongo
+```
+
+Running tests:
+```
+pongo up
+cd <root_folder_of_plugin>
+pongo run ./
+```
+
+If you get a `pongo: command not found` error after installation, add the pongo binary to path with `PATH=$PATH:~/.local/bin`
 
 ### References
 - https://github.com/Kong/kong-plugin

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ http_method = {
 },
 token_claims_to_append_as_headers = {
     type = "array",
-    default = BEARER_TOKEN_HEADERS,
+    default = DEFAULT_TOKEN_HEADERS,
     elements = {
         type = "string"
     }

--- a/README.md
+++ b/README.md
@@ -41,20 +41,16 @@ http_method = {
     type = "string",
     default = "GET"
 },
-add_token_claims_as_headers = {
-    type = "boolean",
-    default = true
-}
-frontier_header_prefix = {
-    type = "string",
-    default = "X-Frontier-"
-},
-appendable_claim_headers = {
+token_claims_to_append_as_headers = {
     type = "array",
     default = BEARER_TOKEN_HEADERS,
     elements = {
         type = "string"
     }
+},
+frontier_header_prefix = {
+    type = "string",
+    default = "X-Frontier-"
 }
 ```
 - For local development linting

--- a/kong-plugin-frontier-0.1.0-1.rockspec
+++ b/kong-plugin-frontier-0.1.0-1.rockspec
@@ -29,6 +29,7 @@ build = {
   modules = {
     -- TODO: add any additional code files added to the plugin
     ["kong.plugins."..plugin_name..".handler"] = "kong/plugins/"..plugin_name.."/handler.lua",
+    ["kong.plugins."..plugin_name..".jwt_decoder"] = "kong/plugins/"..plugin_name.."/jwt_decoder.lua",
     ["kong.plugins."..plugin_name..".schema"] = "kong/plugins/"..plugin_name.."/schema.lua",
     ["kong.plugins."..plugin_name..".access"] = "kong/plugins/"..plugin_name.."/access.lua",
     ["kong.plugins."..plugin_name..".utils"] = "kong/plugins/"..plugin_name.."/utils.lua",

--- a/kong-plugin-frontier-0.1.1-1.rockspec
+++ b/kong-plugin-frontier-0.1.1-1.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "frontier"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "0.1.0"
+local package_version = "0.1.1"
 local rockspec_revision = "1"
 
 local github_account_name = "raystack"

--- a/kong/plugins/frontier/access.lua
+++ b/kong/plugins/frontier/access.lua
@@ -116,7 +116,7 @@ local function check_request_permission(conf, cookies, bearer)
 end
 
 
-local function add_claims_as_headers(conf, user_token)
+local function append_claims_as_headers(conf, user_token)
     local clear_header = kong.service.request.clear_header
     local set_header = kong.service.request.set_header
 
@@ -140,7 +140,7 @@ local function add_claims_as_headers(conf, user_token)
         return fail_auth()
     end
 
-    for _, header_name in iter(conf.appendable_claim_headers) do
+    for _, header_name in iter(conf.token_claims_to_append_as_headers) do
         new_header = conf.frontier_header_prefix .. header_name
         val = claims[header_name]
 
@@ -169,8 +169,8 @@ function _M.run(conf)
         end
     end
 
-    if conf.add_token_claims_as_headers then
-        add_claims_as_headers(conf, user_token)
+    if #conf.token_claims_to_append_as_headers > 0 then
+        append_claims_as_headers(conf, user_token)
     end
 end
 

--- a/kong/plugins/frontier/jwt_decoder.lua
+++ b/kong/plugins/frontier/jwt_decoder.lua
@@ -1,0 +1,16 @@
+local _M = {}
+
+local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
+
+function _M.decode_token(token)
+    local jwt, err = jwt_decoder:new(token)
+
+    if err then
+        ngx.log(ngx.STDERR, err)
+        return nil, err
+    end
+
+    return jwt, nil
+end
+
+return _M

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -54,22 +54,17 @@ local schema = {
                     default = true
                 }
             }, {
-                add_token_claims_as_headers = {
-                    type = "boolean",
-                    default = true
-                }
-            }, {
-                frontier_header_prefix = {
-                    type = "string",
-                    default = "X-Frontier-"
-                }
-            }, {
-                appendable_claim_headers = {
+                token_claims_to_append_as_headers = {
                     type = "array",
                     default = DEFAULT_TOKEN_HEADERS,
                     elements = {
                         type = "string"
                     }
+                }
+            }, {
+                frontier_header_prefix = {
+                    type = "string",
+                    default = "X-Frontier-"
                 }
             }, {
                 rule = {

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -1,6 +1,11 @@
 local typedefs = require "kong.db.schema.typedefs"
 local PLUGIN_NAME = "frontier"
 
+local BEARER_TOKEN_HEADERS = {
+    "sub",
+    "org_ids"
+}
+
 -- https://github.com/Kong/kong-plugin/blob/master/kong/plugins/myplugin/schema.lua
 local schema = {
     name = PLUGIN_NAME,
@@ -47,6 +52,24 @@ local schema = {
                 override_authz_header = {
                     type = "boolean",
                     default = true
+                }
+            }, {
+                add_token_claims_as_headers = {
+                    type = "boolean",
+                    default = true
+                }
+            }, {
+                frontier_header_prefix = {
+                    type = "string",
+                    default = "X-Frontier-"
+                }
+            }, {
+                appendable_claim_headers = {
+                    type = "array",
+                    default = BEARER_TOKEN_HEADERS,
+                    elements = {
+                        type = "string"
+                    }
                 }
             }, {
                 rule = {

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -1,7 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 local PLUGIN_NAME = "frontier"
 
-local BEARER_TOKEN_HEADERS = {
+local DEFAULT_TOKEN_HEADERS = {
     "sub",
     "org_ids"
 }
@@ -66,7 +66,7 @@ local schema = {
             }, {
                 appendable_claim_headers = {
                     type = "array",
-                    default = BEARER_TOKEN_HEADERS,
+                    default = DEFAULT_TOKEN_HEADERS,
                     elements = {
                         type = "string"
                     }

--- a/kong/plugins/frontier/utils.lua
+++ b/kong/plugins/frontier/utils.lua
@@ -10,4 +10,9 @@ function _M.split(s, delimiter)
     return result
 end
 
+-- Trim spaces from the starting of a string
+function _M.ltrim(s)
+    return s:match'^%s*(.*)'
+  end
+
 return _M

--- a/kong/plugins/spec/frontier-test/01-schema_spec.lua
+++ b/kong/plugins/spec/frontier-test/01-schema_spec.lua
@@ -1,0 +1,12 @@
+local PLUGIN_NAME = "frontier"
+local schema_def = require("kong.plugins."..PLUGIN_NAME..".schema")
+local v = require("spec.helpers").validate_plugin_config_schema
+
+
+describe("Plugin: " .. PLUGIN_NAME .. " (schema), ", function()
+    it("minimal conf validates", function()
+        assert(v({ 
+            authn_url = "my_auth_url"
+        }, schema_def))
+    end)
+end)

--- a/kong/plugins/spec/frontier-test/02-handler_spec.lua
+++ b/kong/plugins/spec/frontier-test/02-handler_spec.lua
@@ -1,0 +1,71 @@
+local PLUGIN_NAME = "frontier"
+local helpers = require "spec.helpers"
+local cjson   = require "cjson"
+
+for _, strategy in helpers.each_strategy() do
+    describe("Plugin: " .. PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
+        local client
+
+        lazy_setup(function()
+            local bp = helpers.get_db_utils(strategy, nil, { PLUGIN_NAME })
+            local route1 = bp.routes:insert({
+                hosts = { "test1.com" },
+        })
+        local route2 = bp.routes:insert({
+            hosts = { "test2.com" },
+        })
+        bp.plugins:insert {
+            name = PLUGIN_NAME,
+            route = { id = route1.id },
+            config = {
+            authn_url = "my_sample_url"
+            },
+        }
+        bp.plugins:insert {
+            name = PLUGIN_NAME,
+            route = { id = route2.id },
+            config = {
+                authn_url = "my_sample_url"
+            },
+        }
+        -- start kong
+        assert(helpers.start_kong({
+            -- set the strategy
+            database   = strategy,
+            -- use the custom test template to create a local mock server
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+            -- make sure our plugin gets loaded
+            plugins = "bundled," .. PLUGIN_NAME,
+        }))
+        end)
+
+        lazy_teardown(function()
+            helpers.stop_kong(nil, true)
+        end)
+
+        before_each(function()
+            client = helpers.proxy_client()
+        end)
+
+        after_each(function()
+            if client then client:close() end
+        end)
+
+        describe("Basic", function()
+            it("a request when no authorization header is passed", function()
+            local res = assert(client:send {
+                method  = "GET",
+                path    = "/status/200",
+                headers = {
+                ["Host"] = "test1.com",
+                ["Authorization"] = "",
+                }
+            })
+            local body = assert.res_status(401, res)
+            local json = cjson.decode(body)
+            print(json)
+            assert.equal("unauthorized", json["message"])
+            end)
+        end)
+    end)
+end

--- a/kong/plugins/spec/frontier-test/03-jwt_decoder_spec.lua
+++ b/kong/plugins/spec/frontier-test/03-jwt_decoder_spec.lua
@@ -1,0 +1,16 @@
+local PLUGIN_NAME = "frontier"
+local decoder = require("kong.plugins."..PLUGIN_NAME..".jwt_decoder")
+
+describe("Plugin: " .. PLUGIN_NAME .. " (decoder), ", function()
+    describe("Success", function()
+        it("successfully decodes JWT", function()
+            local token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImxjN29RV25SNFFoOE5Yal9VeGVKbWROTGJkX0RkNHVSZUxBMWVmUGZPZkUiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjE3MDA1NTE2MTUsImdlbiI6InN5c3RlbSIsImlhdCI6MTcwMDU0ODAxNSwiaXNzIjoiZnJvbnRpZXIiLCJqdGkiOiIyM2I0MjA4Yi1mMThhLTQ3MmUtYTkyZS00YzRjZDQzYThlNDUiLCJraWQiOiJsYzdvUVduUjRRaDhOWGpfVXhlSm1kTkxiZF9EZDR1UmVMQTFlZlBmT2ZFIiwibmJmIjoxNzAwNTQ4MDE1LCJvcmdfaWRzIjoiNjc4MDE0MzItZDExNS00YTAzLTlmYjAtODM5MzQxYzU2NjMyIiwic3ViIjoiOGI0ZWRlNDYtYWQ5YS00ZTNiLTlkNjMtMjI2MzIyNjc5MDIzIn0.zGcC_iO1ht6hAyBLvWB2P_aXm57KSKOPhngqJjZHNdEEcy_cmNHeos8EB9h3tU6gNdX0dmJpUjZOkGbdA6hV1nZhEyoeeH8zBSdyTjyy3t2X376dDFzULGbbGXKOsPB6E9YwwJ6HtL_UYjVWqsuMKgHcyVA_lyR2tMqqToTYooMsGsTQKddT7p3lRHfkyUhAhaqBtUOOW_Qu8FnR3a60eXN5SUDmT8K864eqgjGw2xDkjMUF5NY6wX1ahIORhDiYjYyWm5onlWMQGkn_ugKuFX0Vs7EbD6Ur9YN7wO4kw2dazIRtGYvICmZgp92oofatfN43bDtR59ljYFf5k45KyA"
+            local res, err = decoder.decode_token(token)
+
+            assert.equal(nil, err)
+            assert.is.truthy(res["claims"])
+        end)
+    end)
+end)
+
+


### PR DESCRIPTION
This PR adds configuration options which allow addition of JWT claims as headers, before the request is passed to upstream services

The new configuration options are:
- `token_claims_to_append_as_headers` - List[string] - Claims which need to be appended as headers
- `frontier_header_prefix` - String - String to be prefixed with headers being set by the plugin

Additionally, the PR sets up unit tests using Kong Pongo