### PR TITLE
[Draft] feat: add flag to verify org header sent from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ frontier_header_prefix = {
     type = "string",
     default = "X-Frontier-"
 }
+request_organization_id_header = {
+    type = "string",
+    default = "X-Organization-Id"
+},
+verify_request_organization_id_header = {
+    type = "boolean",
+    default = false
+}
 ```
 - For local development linting
 ```

--- a/kong/plugins/frontier/schema.lua
+++ b/kong/plugins/frontier/schema.lua
@@ -67,6 +67,16 @@ local schema = {
                     default = "X-Frontier-"
                 }
             }, {
+                request_organization_id_header = {
+                    type = "string",
+                    default = "X-Organization-Id"
+                }
+            }, {
+                verify_request_organization_id_header = {
+                    type = "boolean",
+                    default = false
+                }
+            }, {
                 rule = {
                     type = "record",
                     fields = {{

--- a/kong/plugins/frontier/utils.lua
+++ b/kong/plugins/frontier/utils.lua
@@ -15,4 +15,14 @@ function _M.ltrim(s)
     return s:match'^%s*(.*)'
   end
 
+function _M.has_value(tab, val)
+    for index, value in ipairs(tab) do
+        if value == val then
+            return true
+        end
+    end
+
+    return false
+end
+
 return _M


### PR DESCRIPTION
Corresponding ticket: [IDE-302](https://linear.app/pixxel/issue/IDE-302/validate-current-org-id-at-api-gateway)

Currently, there is no specific way for backend APIs to know the current org of a logged in user. However, many backend requests rely on the org of the user to choose projects, assets etc. 
In order to solve that, Aurora frontend has started sending `X-Organization_id`. This id is currently not verified.

This PR aims to add verification of `X-Organization-Id` at Kong layer. There are two additions to the schema:

1. `request_organization_id_header` - The field that specifies the header in which org id is sent
2. `verify_request_organization_id_header` - The field which specifies whether the org id is to be validated

When `verify_request_organization_id_header` is set to true, the plugin checks the value of the `request_organization_id_header` header in the list of org_ids in JWT claims of the user.